### PR TITLE
fix: automatically set version at `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,18 @@
 DOCKER := $(shell which docker)
 DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace bufbuild/buf
 
+BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+COMMIT := $(shell git log -1 --format='%H')
+
+# don't override user values
+ifeq (,$(VERSION))
+  VERSION := $(shell git describe --exact-match 2>/dev/null)
+  # if VERSION is empty, then populate it with branch's name and raw commit hash
+  ifeq (,$(VERSION))
+    VERSION := $(BRANCH)-$(COMMIT)
+  endif
+endif
+
 # TODO: Update the ldflags with the app, client & server names
 ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=pooltoy \
 	-X github.com/cosmos/cosmos-sdk/version.AppName=pooltoyd \


### PR DESCRIPTION
Currently, `make install` needs `VERSION` and `COMMIT` passed so that `pooltoy version` does not return an empty string.
This allows to build directly the version name (like done in gaia).